### PR TITLE
[WIP] More robust dataframe types

### DIFF
--- a/src/OmniSci.jl
+++ b/src/OmniSci.jl
@@ -2,7 +2,7 @@ module OmniSci
 
 using Thrift, Random, Sockets, Distributed, DataFrames, Dates, DecFP, GeoInterface
 import Thrift: process, meta, distribute, ThriftMeta, ThriftMetaAttribs
-import Base: show
+import Base: show, convert
 import DataFrames: DataFrame
 
 #### types and enums ####

--- a/src/dataframe_show.jl
+++ b/src/dataframe_show.jl
@@ -1,10 +1,13 @@
 function DataFrame(x::TQueryResult)
 
-    #get column name and whether column is nullable
+    #get column name
     colnames = [desc.col_name for desc in x.row_set.row_desc]
 
+    #get column types and nullable
+    coltypes = [(getcolumntype(desc.col_type._type), desc.col_type.nullable) for desc in x.row_set.row_desc]
+
     #collapse vectors into a single Vector{T, Missing} vector
-    mergecols = [squashbitmask(y) for y in x.row_set.columns]
+    mergecols = [squashbitmask(y, tup) for (y, tup) in zip(x.row_set.columns, coltypes)]
 
     #convert to DataFrame
     df = DataFrame(mergecols)

--- a/src/thrift_code/enums.jl
+++ b/src/thrift_code/enums.jl
@@ -29,6 +29,8 @@ end
 #translated from auto-generated Thrift.jl to more ergonomic enum usage via macro
 @scopedenum TDatumType SMALLINT=Int32(0) INT=Int32(1) BIGINT=Int32(2) FLOAT=Int32(3) DECIMAL=Int32(4) DOUBLE=Int32(5) STR=Int32(6) TIME=Int32(7) TIMESTAMP=Int32(8) DATE=Int32(9) BOOL=Int32(10) INTERVAL_DAY_TIME=Int32(11) INTERVAL_YEAR_MONTH=Int32(12) POINT=Int32(13) LINESTRING=Int32(14) POLYGON=Int32(15) MULTIPOLYGON=Int32(16) TINYINT=Int32(17) GEOMETRY=Int32(18) GEOGRAPHY=Int32(19)
 
+#this function used to translate enum to Julia types
+#if a Julia type isn't defined, mark as String
 function getcolumntype(x::Int32)
     d = Dict(0 => Int16,  #SMALLINT
              1 => Int32,  #INT
@@ -43,10 +45,10 @@ function getcolumntype(x::Int32)
              10 => Bool,  #BOOL
              11 => String,  #INTERVAL_DAY_TIME
              12 => String,  #INTERVAL_YEAR_MONTH
-             13 => Point,  #POINT
-             14 => LineString,  #LINESTRING
-             15 => Polygon,  #POLYGON
-             16 => MultiPolygon,  #MULTIPOLYGON
+             13 => String,  #POINT
+             14 => String,  #LINESTRING
+             15 => String,  #POLYGON
+             16 => String,  #MULTIPOLYGON
              17 => Int8,  #TINYINT
              18 => String,  #GEOMETRY
              19 => String  #GEOGRAPHY

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,7 +112,7 @@ tbldb = sql_execute(conn, "select * from test")
                              Union{Missing, Int32},
                              Union{Missing, Int64},
                              Union{Missing, Float32},
-                             Union{Missing, Float64}, 
+                             Union{Missing, Float64},
                              Union{Missing, Dec64},
                              Union{Missing, String},
                              Union{Missing, String},

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,22 @@ df = DataFrame([tinyintcol, smallintcol, intcol, bigintcol, floatcol, doublecol,
 #load data rowwise from Vector{TStringRow}
 @test load_table(conn, "test", [OmniSci.TStringRow(x) for x in DataFrames.eachrow(df)]) == nothing
 
+#validate return types same as server
+tbldb = sql_execute(conn, "select * from test")
+@test eltypes(tbldb) == Type[Union{Missing, Int8},
+                             Union{Missing, Int16},
+                             Union{Missing, Int32},
+                             Union{Missing, Int64},
+                             Union{Missing, Float32},
+                             Union{Missing, Float64}, 
+                             Union{Missing, Dec64},
+                             Union{Missing, String},
+                             Union{Missing, String},
+                             Union{Missing, Bool},
+                             Union{Missing, Date},
+                             Union{Missing, Time},
+                             Union{Missing, DateTime}]
+
 sql2 = """
 create table test2 (
 col1 tinyint,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using OmniSci, Test, Dates, Random, DataFrames
+using OmniSci, Test, Dates, Random, DataFrames, DecFP
 
 #defaults for OmniSci CPU Docker image
 host="localhost"


### PR DESCRIPTION
Instead of generically typing the columns, use exact types from Thrift struct as part of `sql_execute`.