### PR TITLE
Deprecate license methods

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -431,17 +431,17 @@ get_all_roles_for_user(conn::OmniSciConnection, userName::String; as_df::Bool = 
 
 ######################################## licensing
 
-"""
-    set_license_key(conn::OmniSciConnection, key::String)
-
-
-"""
-set_license_key(conn::OmniSciConnection, key::String) =
-    set_license_key(conn.c, conn.session, key, randstring(32))
-
-"""
-    get_license_claims(conn::OmniSciConnection)
-
-"""
-get_license_claims(conn::OmniSciConnection) =
-    get_license_claims(conn.c, conn.session, randstring(32))
+# """
+#     set_license_key(conn::OmniSciConnection, key::String)
+#
+#
+# """
+# set_license_key(conn::OmniSciConnection, key::String) =
+#     set_license_key(conn.c, conn.session, key, randstring(32))
+#
+# """
+#     get_license_claims(conn::OmniSciConnection)
+#
+# """
+# get_license_claims(conn::OmniSciConnection) =
+#     get_license_claims(conn.c, conn.session, randstring(32))

--- a/src/client.jl
+++ b/src/client.jl
@@ -428,20 +428,3 @@ get_roles(conn::OmniSciConnection; as_df::Bool = true) =
 """
 get_all_roles_for_user(conn::OmniSciConnection, userName::String; as_df::Bool = true) =
     as_df ? DataFrame(Dict("roles" => get_all_roles_for_user(conn.c, conn.session, userName))) : get_all_roles_for_user(conn.c, conn.session, userName)
-
-######################################## licensing
-
-# """
-#     set_license_key(conn::OmniSciConnection, key::String)
-#
-#
-# """
-# set_license_key(conn::OmniSciConnection, key::String) =
-#     set_license_key(conn.c, conn.session, key, randstring(32))
-#
-# """
-#     get_license_claims(conn::OmniSciConnection)
-#
-# """
-# get_license_claims(conn::OmniSciConnection) =
-#     get_license_claims(conn.c, conn.session, randstring(32))

--- a/src/thrift_code/client.jl
+++ b/src/thrift_code/client.jl
@@ -46,27 +46,6 @@ function disconnect(c::MapDClient, session::TSessionId)
   nothing
 end # function disconnect
 
-# # Client callable method for get_server_status
-# function get_server_status(c::MapDClient, session::TSessionId)
-#   p = c.p
-#   c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
-#   Thrift.writeMessageBegin(p, "get_server_status", Thrift.MessageType.CALL, c.seqid)
-#   inp = get_server_status_args()
-#   Thrift.set_field!(inp, :session, session)
-#   Thrift.write(p, inp)
-#   Thrift.writeMessageEnd(p)
-#   Thrift.flush(p.t)
-#
-#   (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
-#   (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
-#   outp = Thrift.read(p, get_server_status_result())
-#   Thrift.readMessageEnd(p)
-#   (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
-#   Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
-#   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
-#   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
-# end # function get_server_status
-
 # Client callable method for get_status
 function get_status(c::MapDClient, session::TSessionId)
   p = c.p
@@ -620,48 +599,3 @@ function get_all_roles_for_user(c::MapDClient, session::TSessionId, userName::St
   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
 end # function get_all_roles_for_user
-
-# # Client callable method for set_license_key
-# function set_license_key(c::MapDClient, session::TSessionId, key::String, nonce::String)
-#   p = c.p
-#   c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
-#   Thrift.writeMessageBegin(p, "set_license_key", Thrift.MessageType.CALL, c.seqid)
-#   inp = set_license_key_args()
-#   Thrift.set_field!(inp, :session, session)
-#   Thrift.set_field!(inp, :key, key)
-#   Thrift.set_field!(inp, :nonce, nonce)
-#   Thrift.write(p, inp)
-#   Thrift.writeMessageEnd(p)
-#   Thrift.flush(p.t)
-#
-#   (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
-#   (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
-#   outp = Thrift.read(p, set_license_key_result())
-#   Thrift.readMessageEnd(p)
-#   (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
-#   Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
-#   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
-#   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
-# end # function set_license_key
-
-# # Client callable method for get_license_claims
-# function get_license_claims(c::MapDClient, session::TSessionId, nonce::String)
-#   p = c.p
-#   c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
-#   Thrift.writeMessageBegin(p, "get_license_claims", Thrift.MessageType.CALL, c.seqid)
-#   inp = get_license_claims_args()
-#   Thrift.set_field!(inp, :session, session)
-#   Thrift.set_field!(inp, :nonce, nonce)
-#   Thrift.write(p, inp)
-#   Thrift.writeMessageEnd(p)
-#   Thrift.flush(p.t)
-#
-#   (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
-#   (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
-#   outp = Thrift.read(p, get_license_claims_result())
-#   Thrift.readMessageEnd(p)
-#   (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
-#   Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
-#   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
-#   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
-# end # function get_license_claims

--- a/src/thrift_code/client.jl
+++ b/src/thrift_code/client.jl
@@ -46,26 +46,26 @@ function disconnect(c::MapDClient, session::TSessionId)
   nothing
 end # function disconnect
 
-# Client callable method for get_server_status
-function get_server_status(c::MapDClient, session::TSessionId)
-  p = c.p
-  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
-  Thrift.writeMessageBegin(p, "get_server_status", Thrift.MessageType.CALL, c.seqid)
-  inp = get_server_status_args()
-  Thrift.set_field!(inp, :session, session)
-  Thrift.write(p, inp)
-  Thrift.writeMessageEnd(p)
-  Thrift.flush(p.t)
-
-  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
-  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
-  outp = Thrift.read(p, get_server_status_result())
-  Thrift.readMessageEnd(p)
-  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
-  Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
-  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
-  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
-end # function get_server_status
+# # Client callable method for get_server_status
+# function get_server_status(c::MapDClient, session::TSessionId)
+#   p = c.p
+#   c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+#   Thrift.writeMessageBegin(p, "get_server_status", Thrift.MessageType.CALL, c.seqid)
+#   inp = get_server_status_args()
+#   Thrift.set_field!(inp, :session, session)
+#   Thrift.write(p, inp)
+#   Thrift.writeMessageEnd(p)
+#   Thrift.flush(p.t)
+#
+#   (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+#   (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+#   outp = Thrift.read(p, get_server_status_result())
+#   Thrift.readMessageEnd(p)
+#   (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+#   Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
+#   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+#   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+# end # function get_server_status
 
 # Client callable method for get_status
 function get_status(c::MapDClient, session::TSessionId)
@@ -621,47 +621,47 @@ function get_all_roles_for_user(c::MapDClient, session::TSessionId, userName::St
   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
 end # function get_all_roles_for_user
 
-# Client callable method for set_license_key
-function set_license_key(c::MapDClient, session::TSessionId, key::String, nonce::String)
-  p = c.p
-  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
-  Thrift.writeMessageBegin(p, "set_license_key", Thrift.MessageType.CALL, c.seqid)
-  inp = set_license_key_args()
-  Thrift.set_field!(inp, :session, session)
-  Thrift.set_field!(inp, :key, key)
-  Thrift.set_field!(inp, :nonce, nonce)
-  Thrift.write(p, inp)
-  Thrift.writeMessageEnd(p)
-  Thrift.flush(p.t)
+# # Client callable method for set_license_key
+# function set_license_key(c::MapDClient, session::TSessionId, key::String, nonce::String)
+#   p = c.p
+#   c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+#   Thrift.writeMessageBegin(p, "set_license_key", Thrift.MessageType.CALL, c.seqid)
+#   inp = set_license_key_args()
+#   Thrift.set_field!(inp, :session, session)
+#   Thrift.set_field!(inp, :key, key)
+#   Thrift.set_field!(inp, :nonce, nonce)
+#   Thrift.write(p, inp)
+#   Thrift.writeMessageEnd(p)
+#   Thrift.flush(p.t)
+#
+#   (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+#   (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+#   outp = Thrift.read(p, set_license_key_result())
+#   Thrift.readMessageEnd(p)
+#   (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+#   Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
+#   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+#   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+# end # function set_license_key
 
-  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
-  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
-  outp = Thrift.read(p, set_license_key_result())
-  Thrift.readMessageEnd(p)
-  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
-  Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
-  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
-  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
-end # function set_license_key
-
-# Client callable method for get_license_claims
-function get_license_claims(c::MapDClient, session::TSessionId, nonce::String)
-  p = c.p
-  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
-  Thrift.writeMessageBegin(p, "get_license_claims", Thrift.MessageType.CALL, c.seqid)
-  inp = get_license_claims_args()
-  Thrift.set_field!(inp, :session, session)
-  Thrift.set_field!(inp, :nonce, nonce)
-  Thrift.write(p, inp)
-  Thrift.writeMessageEnd(p)
-  Thrift.flush(p.t)
-
-  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
-  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
-  outp = Thrift.read(p, get_license_claims_result())
-  Thrift.readMessageEnd(p)
-  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
-  Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
-  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
-  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
-end # function get_license_claims
+# # Client callable method for get_license_claims
+# function get_license_claims(c::MapDClient, session::TSessionId, nonce::String)
+#   p = c.p
+#   c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+#   Thrift.writeMessageBegin(p, "get_license_claims", Thrift.MessageType.CALL, c.seqid)
+#   inp = get_license_claims_args()
+#   Thrift.set_field!(inp, :session, session)
+#   Thrift.set_field!(inp, :nonce, nonce)
+#   Thrift.write(p, inp)
+#   Thrift.writeMessageEnd(p)
+#   Thrift.flush(p.t)
+#
+#   (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+#   (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+#   outp = Thrift.read(p, get_license_claims_result())
+#   Thrift.readMessageEnd(p)
+#   (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+#   Thrift.has_field(outp, :e) && throw(Thrift.get_field(outp, :e))
+#   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+#   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+# end # function get_license_claims

--- a/src/thrift_code/types.jl
+++ b/src/thrift_code/types.jl
@@ -365,21 +365,6 @@ mutable struct disconnect_result
 end # mutable struct disconnect_result
 meta(t::Type{disconnect_result}) = meta(t, Symbol[:e], Int[1], Dict{Symbol,Any}())
 
-# # types encapsulating arguments and return values of method get_server_status
-#
-# mutable struct get_server_status_args <: Thrift.TMsg
-#   session::TSessionId
-#   get_server_status_args() = (o=new(); fillunset(o); o)
-# end # mutable struct get_server_status_args
-#
-# mutable struct get_server_status_result
-#   success::TServerStatus
-#   e::TMapDException
-#   get_server_status_result() = (o=new(); fillunset(o); o)
-#   get_server_status_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
-# end # mutable struct get_server_status_result
-# meta(t::Type{get_server_status_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
-
 # types encapsulating arguments and return values of method get_status
 
 mutable struct get_status_args <: Thrift.TMsg
@@ -809,41 +794,6 @@ mutable struct get_all_roles_for_user_result
   get_all_roles_for_user_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
 end # mutable struct get_all_roles_for_user_result
 meta(t::Type{get_all_roles_for_user_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
-
-# # types encapsulating arguments and return values of method set_license_key
-#
-# mutable struct set_license_key_args <: Thrift.TMsg
-#   session::TSessionId
-#   key::String
-#   nonce::String
-#   set_license_key_args() = (o=new(); fillunset(o); o)
-# end # mutable struct set_license_key_args
-# meta(t::Type{set_license_key_args}) = meta(t, Symbol[], Int[], Dict{Symbol,Any}(:nonce => ""))
-#
-# mutable struct set_license_key_result
-#   success::TLicenseInfo
-#   e::TMapDException
-#   set_license_key_result() = (o=new(); fillunset(o); o)
-#   set_license_key_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
-# end # mutable struct set_license_key_result
-# meta(t::Type{set_license_key_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
-#
-# # types encapsulating arguments and return values of method get_license_claims
-#
-# mutable struct get_license_claims_args <: Thrift.TMsg
-#   session::TSessionId
-#   nonce::String
-#   get_license_claims_args() = (o=new(); fillunset(o); o)
-# end # mutable struct get_license_claims_args
-# meta(t::Type{get_license_claims_args}) = meta(t, Symbol[], Int[], Dict{Symbol,Any}(:nonce => ""))
-#
-# mutable struct get_license_claims_result
-#   success::TLicenseInfo
-#   e::TMapDException
-#   get_license_claims_result() = (o=new(); fillunset(o); o)
-#   get_license_claims_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
-# end # mutable struct get_license_claims_result
-# meta(t::Type{get_license_claims_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
 
 # Client implementation for MapD service
 mutable struct MapDClient <: MapDClientBase

--- a/src/thrift_code/types.jl
+++ b/src/thrift_code/types.jl
@@ -365,20 +365,20 @@ mutable struct disconnect_result
 end # mutable struct disconnect_result
 meta(t::Type{disconnect_result}) = meta(t, Symbol[:e], Int[1], Dict{Symbol,Any}())
 
-# types encapsulating arguments and return values of method get_server_status
-
-mutable struct get_server_status_args <: Thrift.TMsg
-  session::TSessionId
-  get_server_status_args() = (o=new(); fillunset(o); o)
-end # mutable struct get_server_status_args
-
-mutable struct get_server_status_result
-  success::TServerStatus
-  e::TMapDException
-  get_server_status_result() = (o=new(); fillunset(o); o)
-  get_server_status_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
-end # mutable struct get_server_status_result
-meta(t::Type{get_server_status_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
+# # types encapsulating arguments and return values of method get_server_status
+#
+# mutable struct get_server_status_args <: Thrift.TMsg
+#   session::TSessionId
+#   get_server_status_args() = (o=new(); fillunset(o); o)
+# end # mutable struct get_server_status_args
+#
+# mutable struct get_server_status_result
+#   success::TServerStatus
+#   e::TMapDException
+#   get_server_status_result() = (o=new(); fillunset(o); o)
+#   get_server_status_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+# end # mutable struct get_server_status_result
+# meta(t::Type{get_server_status_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
 
 # types encapsulating arguments and return values of method get_status
 
@@ -810,40 +810,40 @@ mutable struct get_all_roles_for_user_result
 end # mutable struct get_all_roles_for_user_result
 meta(t::Type{get_all_roles_for_user_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
 
-# types encapsulating arguments and return values of method set_license_key
-
-mutable struct set_license_key_args <: Thrift.TMsg
-  session::TSessionId
-  key::String
-  nonce::String
-  set_license_key_args() = (o=new(); fillunset(o); o)
-end # mutable struct set_license_key_args
-meta(t::Type{set_license_key_args}) = meta(t, Symbol[], Int[], Dict{Symbol,Any}(:nonce => ""))
-
-mutable struct set_license_key_result
-  success::TLicenseInfo
-  e::TMapDException
-  set_license_key_result() = (o=new(); fillunset(o); o)
-  set_license_key_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
-end # mutable struct set_license_key_result
-meta(t::Type{set_license_key_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
-
-# types encapsulating arguments and return values of method get_license_claims
-
-mutable struct get_license_claims_args <: Thrift.TMsg
-  session::TSessionId
-  nonce::String
-  get_license_claims_args() = (o=new(); fillunset(o); o)
-end # mutable struct get_license_claims_args
-meta(t::Type{get_license_claims_args}) = meta(t, Symbol[], Int[], Dict{Symbol,Any}(:nonce => ""))
-
-mutable struct get_license_claims_result
-  success::TLicenseInfo
-  e::TMapDException
-  get_license_claims_result() = (o=new(); fillunset(o); o)
-  get_license_claims_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
-end # mutable struct get_license_claims_result
-meta(t::Type{get_license_claims_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
+# # types encapsulating arguments and return values of method set_license_key
+#
+# mutable struct set_license_key_args <: Thrift.TMsg
+#   session::TSessionId
+#   key::String
+#   nonce::String
+#   set_license_key_args() = (o=new(); fillunset(o); o)
+# end # mutable struct set_license_key_args
+# meta(t::Type{set_license_key_args}) = meta(t, Symbol[], Int[], Dict{Symbol,Any}(:nonce => ""))
+#
+# mutable struct set_license_key_result
+#   success::TLicenseInfo
+#   e::TMapDException
+#   set_license_key_result() = (o=new(); fillunset(o); o)
+#   set_license_key_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+# end # mutable struct set_license_key_result
+# meta(t::Type{set_license_key_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
+#
+# # types encapsulating arguments and return values of method get_license_claims
+#
+# mutable struct get_license_claims_args <: Thrift.TMsg
+#   session::TSessionId
+#   nonce::String
+#   get_license_claims_args() = (o=new(); fillunset(o); o)
+# end # mutable struct get_license_claims_args
+# meta(t::Type{get_license_claims_args}) = meta(t, Symbol[], Int[], Dict{Symbol,Any}(:nonce => ""))
+#
+# mutable struct get_license_claims_result
+#   success::TLicenseInfo
+#   e::TMapDException
+#   get_license_claims_result() = (o=new(); fillunset(o); o)
+#   get_license_claims_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+# end # mutable struct get_license_claims_result
+# meta(t::Type{get_license_claims_result}) = meta(t, Symbol[:success, :e], Int[0, 1], Dict{Symbol,Any}())
 
 # Client implementation for MapD service
 mutable struct MapDClient <: MapDClientBase

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,8 +209,8 @@ clear_cpu = OmniSci.clear_cpu_memory(conn)
 execmode = OmniSci.set_execution_mode(conn, TExecuteMode.CPU)
 @test typeof(execmode) == Nothing
 
-glc = OmniSci.get_license_claims(conn)
-@test typeof(glc) == OmniSci.TLicenseInfo
+# glc = OmniSci.get_license_claims(conn)
+# @test typeof(glc) == OmniSci.TLicenseInfo
 
 mem = OmniSci.get_memory(conn, "cpu")
 @test typeof(mem) == Vector{OmniSci.TNodeMemoryInfo}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,8 +209,5 @@ clear_cpu = OmniSci.clear_cpu_memory(conn)
 execmode = OmniSci.set_execution_mode(conn, TExecuteMode.CPU)
 @test typeof(execmode) == Nothing
 
-# glc = OmniSci.get_license_claims(conn)
-# @test typeof(glc) == OmniSci.TLicenseInfo
-
 mem = OmniSci.get_memory(conn, "cpu")
 @test typeof(mem) == Vector{OmniSci.TNodeMemoryInfo}


### PR DESCRIPTION
These can really be handled in Immerse, they don't need to be part of an 
analytics package