### PR TITLE
need floor before Int64

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -29,7 +29,7 @@ myDateTime(x::Missing) = missing
 myDateTime(x) = DateTime(x)
 
 mydatetime2unix(x::Missing) = missing
-mydatetime2unix(x) = datetime2unix(x)
+mydatetime2unix(x) = datetime2unix(x) |> floor
 
 epochdays(x::Missing) = missing
 epochdays(x) = (x - Dates.Date("1970-01-01")).value

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -29,7 +29,7 @@ myDateTime(x::Missing) = missing
 myDateTime(x) = DateTime(x)
 
 mydatetime2unix(x::Missing) = missing
-mydatetime2unix(x) = datetime2unix(x) |> floor
+mydatetime2unix(x) = datetime2unix(floor(x, Dates.Second))
 
 epochdays(x::Missing) = missing
 epochdays(x) = (x - Dates.Date("1970-01-01")).value


### PR DESCRIPTION
I worked on Julia Version 1.2.0 (2019-08-20) with omnisci/core-os-cpu docker.

I bumped into trouble when applying TColumn on Datetime column.
I think we need "floor" before converting into Int64 and it works well.

No obligation, just want to have it worked well :-)