### PR TITLE
Add support for optional fields debug, success in TQueryResult

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OmniSci"
 uuid = "085fdc97-bbf0-5359-b689-34bac5cd65e1"
-author = ["Randy Zwitch <randy.zwitch@omnisci.com>"]
-version = "0.9.0"
+author = ["Andrew Seidl <dev@aas.io>", "Randy Zwitch <randy.zwitch@omnisci.com>"]
+version = "0.10.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/README.md
+++ b/README.md
@@ -10,5 +10,10 @@ Codecov: [![codecov](https://codecov.io/gh/omnisci/OmniSci.jl/branch/master/grap
 JuliaCon 2019 OmniSci.jl announcement: https://www.youtube.com/watch?v=coPbmYuUah0 <br>
 Announcement blog post: [Announcing OmniSci.jl: A Julia Client for OmniSci](https://www.omnisci.com/blog/announcing-omnisci.jl-a-julia-client-for-omnisci)
 
+## Support
+
+This package is not officially supported by OmniSci, Inc. and is maintained only on a best-effort basis.
+
 ## Description
+
 This package is an Apache Thrift-based client for OmniSci, with similar functionality to our Python package [pymapd](https://pymapd.readthedocs.io/en/latest/). Because of the rapid pace of [OmniSciDB](https://github.com/omnisci/omniscidb) development, this package will attempt to always run against the most recent version of OmniSci. In most cases, OmniSci.jl should be backwards compatible to the last few OmniSciDB releases, but if you run into an issue, the first step would be to run the OmniSci.jl test suite against the [newest stable CPU Docker image](https://hub.docker.com/r/omnisci/core-os-cpu) to validate the tests pass.

--- a/src/mapd/mapd_types.jl
+++ b/src/mapd/mapd_types.jl
@@ -213,8 +213,11 @@ mutable struct TQueryResult <: Thrift.TMsg
   execution_time_ms::Int64
   total_time_ms::Int64
   nonce::String
+  debug::String
+  success::Bool
   TQueryResult() = (o=new(); fillunset(o); o)
 end # mutable struct TQueryResult
+meta(t::Type{TQueryResult}) = meta(t, Symbol[:debug,:success], Int[], Dict{Symbol,Any}(:success => true))
 
 mutable struct TDataFrame <: Thrift.TMsg
   sm_handle::Vector{UInt8}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,7 +63,7 @@ end
                           Union{Missing, String},
                           Union{Missing, String},
                           Union{Missing, String},
-                          Union{Missing, GeoInterface.MultiPolygon}
+                          GeoInterface.MultiPolygon
                           ]
 end
 


### PR DESCRIPTION
OmniSciDB added two optional fields to TQueryResult in v5.2.0, which
apparently requires some explicit handling to support with this thrift
lib for julia.

Previously the connector would throw a keyerror if the server returned
a TQueryResult with these optional fields.